### PR TITLE
Update r-lib GitHub action

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -131,9 +131,10 @@ jobs:
 
       - name: Set up R
         if: steps.check-rmd.outputs.count != 0
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
-          r-version: 'release'
+          use-public-rspm: true
+          install-r: false
 
       - name: Install needed packages
         if: steps.check-rmd.outputs.count != 0

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -48,9 +48,10 @@ jobs:
 
       - name: Set up R
         if: steps.check-rmd.outputs.count != 0
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
-          r-version: 'release'
+          use-public-rspm: true
+          install-r: false
 
       - name: Restore R Cache
         if: steps.check-rmd.outputs.count != 0


### PR DESCRIPTION
This patch follows one from carpentries lesson template, and uses an up-to-date r-lib action. This should prevent "Error: Unable to resolve action `r-lib/actions@master`, unable to find version `master`" in the build-website job.